### PR TITLE
Add Either support to JSONValue extract operator

### DIFF
--- a/Tyro/JSONOperators.swift
+++ b/Tyro/JSONOperators.swift
@@ -37,6 +37,10 @@ public func <?? <B : JSONFormatterType> (lhs : B?, rhs : JSONKeypath) -> [String
 
 /// JSONValue decoding operators
 
+public func <? <A : FromJSON where A.T == A>(lhs : JSONValue?, rhs : JSONKeypath) -> Either<JSONError, A> {
+    return (lhs?[rhs]?.value()).toEither(JSONError.Custom("Could not find value at keypath \(rhs) in JSONValue : \(lhs)"))
+}
+
 public func <? <A : FromJSON where A.T == A>(lhs : JSONValue?, rhs : JSONKeypath) -> A? {
     return lhs?[rhs]?.value()
 }


### PR DESCRIPTION
Allow deserialization to Either type, which allows fine grained json path errors. 

```
static func fromJSON(value: JSONValue) -> Either<JSONError, User> {
        let name: Either<JSONError, String> = value <? "name"
        let address: Either<JSONError, String> = value <? "address"

        return (curry(User.init)
            <^> name
            <*> address)
    }
```
